### PR TITLE
Closes SICKAG/sick_ldmrs_laser#2

### DIFF
--- a/sick_ldmrs_driver/launch/sick_ldmrs_node.launch
+++ b/sick_ldmrs_driver/launch/sick_ldmrs_node.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="sick_ldmrs_node" pkg="sick_ldmrs_driver" type="sick_ldmrs_node" output="screen" />
+  <node name="sick_ldmrs_node" pkg="sick_ldmrs_driver" type="sick_ldmrs_node" output="screen">
   <!-- defaults (dynamically reconfigurable):
     <param name="frame_id" type="str" value="ldmrs" />
     <param name="start_angle" type="double" value="0.872664625997" />
@@ -36,3 +36,4 @@
   </node>
 
 </launch>
+

--- a/sick_ldmrs_driver/src/sick_ldmrs_node.cpp
+++ b/sick_ldmrs_driver/src/sick_ldmrs_node.cpp
@@ -539,9 +539,10 @@ int main(int argc, char **argv)
   ROS_INFO("Adding the LDMRS device.");
   devices::LDMRS* ldmrs = new devices::LDMRS(&manager);
   ldmrs->setWeWantObjectData(true);
-  std::string hostname;
-  ros::NodeHandle nh;
+  std::string hostname = "192.168.1.202";
+  ros::NodeHandle nh("~");
   nh.param<std::string>("hostname", hostname, "192.168.0.1");
+  ROS_INFO("Set IP address to %s", hostname.c_str());
   ldmrs->setIpAddress(hostname);
   name = "LDMRS-1";
   id = 1;

--- a/sick_ldmrs_driver/src/sick_ldmrs_node.cpp
+++ b/sick_ldmrs_driver/src/sick_ldmrs_node.cpp
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
   ROS_INFO("Adding the LDMRS device.");
   devices::LDMRS* ldmrs = new devices::LDMRS(&manager);
   ldmrs->setWeWantObjectData(true);
-  std::string hostname = "192.168.1.202";
+  std::string hostname;
   ros::NodeHandle nh("~");
   nh.param<std::string>("hostname", hostname, "192.168.0.1");
   ROS_INFO("Set IP address to %s", hostname.c_str());


### PR DESCRIPTION
Closes SICKAG/sick_ldmrs_laser#2
hostname is private parameter so create a private NodeHandle (see: http://answers.ros.org/question/189916/why-cant-i-get-my-rosrun-parameters/)