### PR TITLE
add libsick_ldmrs as dependency

### DIFF
--- a/sick_ldmrs_driver/package.xml
+++ b/sick_ldmrs_driver/package.xml
@@ -18,6 +18,7 @@
 
   <depend>diagnostic_updater</depend>
   <depend>dynamic_reconfigure</depend>
+  <depend>libsick_ldmrs</depend>
   <depend>pcl_conversions</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
the library is missing in the dependencies and build success is random